### PR TITLE
Add interactive ferry lines map of Japan

### DIFF
--- a/ferry-lines-japan.html
+++ b/ferry-lines-japan.html
@@ -4,342 +4,394 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Ferry Lines to Japan</title>
-  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
   <style>
     * { box-sizing: border-box; margin: 0; padding: 0; }
-    body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; background: #0d1117; color: #e6edf3; }
+    body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; background: #0d1117; color: #e6edf3; display: flex; flex-direction: column; height: 100vh; overflow: hidden; }
 
     #header {
-      padding: 16px 24px;
+      flex-shrink: 0;
+      padding: 14px 24px;
       background: #161b22;
       border-bottom: 1px solid #30363d;
-      display: flex;
-      align-items: center;
-      gap: 12px;
+      display: flex; align-items: center; gap: 14px;
     }
-    #header h1 { font-size: 1.3rem; font-weight: 600; }
-    #header span { font-size: 0.85rem; color: #8b949e; }
+    #header h1 { font-size: 1.2rem; font-weight: 600; }
+    #header span { font-size: 0.82rem; color: #8b949e; }
 
-    #map { width: 100%; height: calc(100vh - 57px); }
+    #map-wrap { flex: 1; position: relative; overflow: hidden; }
+
+    svg#map {
+      width: 100%; height: 100%;
+      background: #1a2e45;
+      cursor: default;
+    }
+
+    /* Land polygons */
+    .land-mainland { fill: #2a3d28; stroke: #3a5535; stroke-width: 0.8; }
+    .land-japan    { fill: #304028; stroke: #4a6040; stroke-width: 0.8; }
+
+    /* Route lines */
+    .route { stroke-width: 2.2; fill: none; stroke-linecap: round; cursor: pointer; transition: stroke-width 0.15s, opacity 0.15s; }
+    .route:hover { stroke-width: 4; }
+    .route-china  { stroke: #f78166; }
+    .route-korea  { stroke: #58a6ff; }
+    .route-russia { stroke: #bc8cff; opacity: 0.45; stroke-dasharray: 7 5; }
+    .route-seasonal { stroke-dasharray: 10 5; opacity: 0.8; }
+
+    /* Direction arrows along routes */
+    .arrow { fill: none; stroke-width: 1.8; stroke-linecap: round; stroke-linejoin: round; pointer-events: none; }
+
+    /* Port markers */
+    .port { cursor: pointer; }
+    .port-dot { transition: r 0.15s; }
+    .port:hover .port-dot { r: 9; }
+    .port-japan   .port-dot { fill: #f0c040; stroke: #0d1117; stroke-width: 1.5; }
+    .port-foreign .port-dot { fill: #adbac7; stroke: #0d1117; stroke-width: 1.5; }
+
+    /* Port labels */
+    .port-label {
+      font-size: 10.5px;
+      fill: #d1dce8;
+      pointer-events: none;
+      text-shadow: 0 1px 3px #0d1117;
+      paint-order: stroke;
+      stroke: #0d1117;
+      stroke-width: 3px;
+      stroke-linejoin: round;
+    }
+
+    /* Grid lines */
+    .gridline { stroke: #1e3550; stroke-width: 0.5; fill: none; }
+    .gridlabel { font-size: 9px; fill: #2c4a68; }
 
     /* Legend */
-    .legend {
-      background: rgba(22, 27, 34, 0.95);
-      border: 1px solid #30363d;
-      border-radius: 8px;
-      padding: 12px 16px;
-      min-width: 200px;
+    #legend {
+      position: absolute; bottom: 20px; left: 20px;
+      background: rgba(22, 27, 34, 0.92);
+      border: 1px solid #30363d; border-radius: 8px;
+      padding: 12px 16px; min-width: 190px;
       backdrop-filter: blur(4px);
+      font-size: 0.8rem;
     }
-    .legend h4 { font-size: 0.78rem; text-transform: uppercase; letter-spacing: 0.08em; color: #8b949e; margin-bottom: 10px; }
-    .legend-item { display: flex; align-items: center; gap: 8px; margin-bottom: 7px; font-size: 0.83rem; }
-    .legend-line { width: 32px; height: 3px; border-radius: 2px; }
-    .legend-dot { width: 10px; height: 10px; border-radius: 50%; border: 2px solid #fff; }
+    #legend h4 { font-size: 0.68rem; text-transform: uppercase; letter-spacing: 0.09em; color: #8b949e; margin-bottom: 8px; }
+    #legend h4:not(:first-child) { margin-top: 10px; }
+    .leg-row { display: flex; align-items: center; gap: 8px; margin-bottom: 5px; }
+    .leg-line { width: 28px; height: 3px; border-radius: 2px; }
+    .leg-dot  { width: 9px; height: 9px; border-radius: 50%; border: 2px solid #0d1117; flex-shrink: 0; }
 
-    /* Popup */
-    .leaflet-popup-content-wrapper {
-      background: #161b22;
-      border: 1px solid #30363d;
-      border-radius: 8px;
-      color: #e6edf3;
-      box-shadow: 0 8px 24px rgba(0,0,0,0.5);
+    /* Tooltip / popup */
+    #tooltip {
+      position: absolute; pointer-events: none;
+      background: rgba(22, 27, 34, 0.97);
+      border: 1px solid #30363d; border-radius: 7px;
+      padding: 10px 14px; max-width: 260px;
+      display: none; z-index: 10;
+      box-shadow: 0 6px 20px rgba(0,0,0,0.55);
     }
-    .leaflet-popup-tip { background: #161b22; }
-    .leaflet-popup-content { margin: 12px 16px; min-width: 180px; }
-    .popup-title { font-weight: 600; font-size: 0.95rem; margin-bottom: 6px; }
-    .popup-meta { font-size: 0.8rem; color: #8b949e; line-height: 1.6; }
-    .popup-badge {
-      display: inline-block;
-      padding: 2px 8px;
-      border-radius: 12px;
-      font-size: 0.72rem;
-      font-weight: 600;
-      margin-top: 6px;
+    #tooltip .tt-title { font-weight: 600; font-size: 0.9rem; margin-bottom: 5px; }
+    #tooltip .tt-meta  { font-size: 0.78rem; color: #8b949e; line-height: 1.65; }
+    #tooltip .tt-badge {
+      display: inline-block; margin-top: 6px;
+      padding: 2px 9px; border-radius: 10px; font-size: 0.7rem; font-weight: 600;
     }
-    .badge-active { background: #1f6feb; color: #fff; }
-    .badge-suspended { background: #6e4040; color: #ffa0a0; }
-    .badge-seasonal { background: #3d4a1f; color: #b5e853; }
+    .badge-active    { background: #1f4a8b; color: #58a6ff; }
+    .badge-suspended { background: #4a1f1f; color: #ff7b72; }
+    .badge-seasonal  { background: #2a3d10; color: #a5d46a; }
 
-    /* Tooltip */
-    .leaflet-tooltip {
-      background: #161b22;
-      border: 1px solid #30363d;
-      color: #e6edf3;
-      font-size: 0.78rem;
-      padding: 4px 8px;
-      border-radius: 4px;
-    }
-    .leaflet-tooltip-left::before, .leaflet-tooltip-right::before { border-right-color: #30363d; border-left-color: #30363d; }
+    /* Scale bar */
+    #scalebar { position: absolute; bottom: 20px; right: 20px; font-size: 9px; color: #4a6a88; }
+    #scalebar line { stroke: #4a6a88; stroke-width: 1.5; }
   </style>
 </head>
 <body>
-
 <div id="header">
   <h1>Ferry Lines to Japan</h1>
-  <span>International ferry routes — hover routes &amp; ports for details</span>
+  <span>International routes — click routes &amp; ports for details</span>
 </div>
-<div id="map"></div>
 
-<script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+<div id="map-wrap">
+  <svg id="map" viewBox="0 0 1400 900" preserveAspectRatio="xMidYMid meet"></svg>
+  <div id="tooltip"></div>
+  <div id="legend">
+    <h4>Origin</h4>
+    <div class="leg-row"><div class="leg-line" style="background:#f78166"></div> China</div>
+    <div class="leg-row"><div class="leg-line" style="background:#58a6ff"></div> South Korea</div>
+    <div class="leg-row"><div class="leg-line" style="background:#bc8cff;opacity:.6"></div> Russia</div>
+    <h4>Status</h4>
+    <div class="leg-row"><div class="leg-line" style="background:#aaa"></div> Active</div>
+    <div class="leg-row"><div class="leg-line" style="background:#aaa;background:repeating-linear-gradient(90deg,#aaa 0,#aaa 8px,transparent 8px,transparent 13px)"></div> Seasonal</div>
+    <div class="leg-row"><div class="leg-line" style="background:repeating-linear-gradient(90deg,#666 0,#666 6px,transparent 6px,transparent 11px)"></div> Suspended</div>
+    <h4>Ports</h4>
+    <div class="leg-row"><div class="leg-dot" style="background:#f0c040"></div> Japan port</div>
+    <div class="leg-row"><div class="leg-dot" style="background:#adbac7"></div> Foreign port</div>
+  </div>
+</div>
+
 <script>
-// ── Map setup ──────────────────────────────────────────────────────────────
-const map = L.map('map', { center: [34, 128], zoom: 5, zoomControl: true });
+// ── Projection ─────────────────────────────────────────────────────────────
+const W = 1400, H = 900;
+const LON_MIN = 114, LON_MAX = 149;
+const LAT_MIN = 22,  LAT_MAX = 47;
 
-L.tileLayer('https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png', {
-  attribution: '© <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors © <a href="https://carto.com/">CARTO</a>',
-  subdomains: 'abcd', maxZoom: 19
-}).addTo(map);
+function proj(lon, lat) {
+  return {
+    x: (lon - LON_MIN) / (LON_MAX - LON_MIN) * W,
+    y: (LAT_MAX - lat) / (LAT_MAX - LAT_MIN) * H,
+  };
+}
 
-// ── Colours by country of origin ──────────────────────────────────────────
-const COLORS = {
-  china:  '#f78166',  // red-orange
-  korea:  '#58a6ff',  // blue
-  russia: '#bc8cff',  // purple
-  taiwan: '#ffa657',  // amber
+function svgPt(lon, lat) { const p = proj(lon, lat); return `${p.x.toFixed(1)},${p.y.toFixed(1)}`; }
+
+function pathStr(pts) {
+  return 'M' + pts.map(([lo, la]) => svgPt(lo, la)).join(' L') + ' Z';
+}
+
+// ── Land polygons ──────────────────────────────────────────────────────────
+const LAND = {
+  continent: [
+    [114.0,47.0],[131.0,47.0],[131.9,43.1],[131.2,42.3],
+    [130.6,42.3],[129.8,41.8],[129.2,40.7],[127.5,39.2],
+    [128.6,38.2],[129.1,37.5],[129.4,36.0],[129.4,35.5],
+    [129.0,35.1],[128.5,34.9],[128.0,34.7],[127.0,34.8],
+    [126.5,34.9],[126.4,35.3],[126.3,36.0],[126.1,36.7],
+    [126.6,37.5],[126.3,38.0],
+    [125.4,38.7],[124.8,39.5],[124.4,40.1],
+    [122.5,40.5],[122.1,39.0],[121.0,38.6],[120.2,38.9],
+    [117.5,38.5],[117.2,38.0],
+    [119.0,37.0],[122.5,37.8],[122.3,37.0],
+    [120.4,36.1],[119.5,35.5],[119.2,34.6],
+    [121.5,31.5],[121.6,31.2],
+    [120.7,28.0],[119.8,27.0],[119.3,26.1],
+    [118.1,24.5],[116.0,23.0],[114.2,22.4],
+    [114.0,22.0],
+  ],
+  taiwan: [
+    [121.5,25.3],[122.0,24.8],[121.5,22.0],
+    [120.8,22.0],[120.1,22.7],[120.0,23.5],
+    [120.7,24.5],[121.0,25.0],
+  ],
+  hokkaido: [
+    [140.7,41.8],[141.0,42.0],[141.5,42.5],[143.2,42.2],
+    [144.9,43.0],[145.1,44.1],[144.3,44.5],[142.5,45.0],
+    [141.7,45.4],[141.0,44.3],[141.0,43.2],[140.8,42.5],
+  ],
+  honshu: [
+    [130.94,33.95],[131.6,34.4],[131.8,34.7],[132.5,34.8],
+    [132.8,35.0],[133.2,35.5],[133.6,35.7],[134.2,35.5],
+    [135.2,35.5],[135.4,35.6],[136.1,36.0],[137.2,36.7],
+    [139.0,37.9],[139.3,38.5],[140.1,39.7],[140.5,41.1],
+    [141.5,41.5],[141.5,40.8],[141.5,38.3],[141.0,37.0],
+    [140.9,35.7],[139.9,35.3],[139.5,35.2],[138.9,34.6],
+    [138.1,34.6],[137.7,34.6],[137.0,34.9],[136.8,34.5],
+    [136.0,33.4],[135.8,33.4],[135.2,34.0],[135.2,34.7],
+    [135.5,34.8],[135.8,34.5],[134.8,34.3],[134.5,34.2],
+    [134.2,34.1],[133.6,34.2],[133.2,34.4],[132.6,34.8],
+    [132.2,35.1],[131.8,35.2],[131.2,34.9],
+  ],
+  shikoku: [
+    [132.7,33.9],[132.6,33.4],[133.0,32.7],[133.5,32.8],
+    [134.2,33.2],[134.8,33.6],[134.7,34.0],[134.5,34.2],
+    [134.0,34.2],[133.6,34.2],[133.0,34.2],[132.8,34.0],
+  ],
+  kyushu: [
+    [130.94,33.95],[130.8,33.9],[130.4,33.6],[130.0,33.2],
+    [129.7,33.2],[129.8,32.6],[130.0,32.0],[130.5,31.5],
+    [130.7,31.0],[131.0,31.5],[131.4,32.0],[131.7,32.5],
+    [131.7,33.2],[131.5,33.5],[131.0,33.9],
+  ],
+  okinawa: [
+    [127.7,26.2],[127.9,26.4],[128.3,26.4],[128.5,26.2],
+    [128.3,26.0],[128.0,25.9],[127.7,26.0],
+  ],
 };
 
-// ── Port data ──────────────────────────────────────────────────────────────
-const ports = {
-  // Japanese ports
-  osaka:        { name: 'Osaka',          latlng: [34.646, 135.406], country: 'Japan' },
-  kobe:         { name: 'Kobe',           latlng: [34.682, 135.185], country: 'Japan' },
-  shimonoseki:  { name: 'Shimonoseki',    latlng: [33.954, 130.937], country: 'Japan' },
-  hakata:       { name: 'Hakata (Fukuoka)',latlng: [33.598, 130.399], country: 'Japan' },
-  sakaiminato:  { name: 'Sakaiminato',    latlng: [35.546, 133.228], country: 'Japan' },
-  naha:         { name: 'Naha (Okinawa)', latlng: [26.218, 127.665], country: 'Japan' },
-  izuhara:      { name: 'Izuhara (Tsushima)',latlng: [34.199, 129.290], country: 'Japan' },
-  hiroshima:    { name: 'Hiroshima',      latlng: [34.391, 132.455], country: 'Japan' },
-  // Chinese ports
-  shanghai:     { name: 'Shanghai',       latlng: [31.381, 121.618], country: 'China' },
-  tianjin:      { name: 'Tianjin (Xingang)', latlng: [38.993, 117.728], country: 'China' },
-  dalian:       { name: 'Dalian',         latlng: [38.929, 121.641], country: 'China' },
-  qingdao:      { name: 'Qingdao',        latlng: [36.063, 120.361], country: 'China' },
-  weihai:       { name: 'Weihai',         latlng: [37.506, 122.116], country: 'China' },
-  // Korean ports
-  busan:        { name: 'Busan',          latlng: [35.097, 129.032], country: 'South Korea' },
-  incheon:      { name: 'Incheon',        latlng: [37.455, 126.706], country: 'South Korea' },
-  donghae:      { name: 'Donghae',        latlng: [37.524, 129.114], country: 'South Korea' },
-  // Russian ports
-  vladivostok:  { name: 'Vladivostok',    latlng: [43.115, 131.882], country: 'Russia' },
+// ── Ports ──────────────────────────────────────────────────────────────────
+const PORTS = {
+  osaka:       { name:'Osaka',             lon:135.406, lat:34.646, jp:true,  labelOff:[ 6,-6] },
+  kobe:        { name:'Kobe',              lon:135.185, lat:34.682, jp:true,  labelOff:[-36,-6] },
+  shimonoseki: { name:'Shimonoseki',       lon:130.937, lat:33.954, jp:true,  labelOff:[ 6, 12] },
+  hakata:      { name:'Hakata (Fukuoka)',  lon:130.399, lat:33.598, jp:true,  labelOff:[-80, 14] },
+  sakaiminato: { name:'Sakaiminato',       lon:133.228, lat:35.546, jp:true,  labelOff:[ 6, -6] },
+  naha:        { name:'Naha (Okinawa)',    lon:127.665, lat:26.218, jp:true,  labelOff:[ 8,  0] },
+  izuhara:     { name:'Izuhara (Tsushima)',lon:129.290, lat:34.199, jp:true,  labelOff:[ 8,  3] },
+  shanghai:    { name:'Shanghai',          lon:121.618, lat:31.381, jp:false, labelOff:[ 8,  3] },
+  tianjin:     { name:'Tianjin',           lon:117.728, lat:38.993, jp:false, labelOff:[ 8,  3] },
+  dalian:      { name:'Dalian',            lon:121.641, lat:38.929, jp:false, labelOff:[ 8,  3] },
+  qingdao:     { name:'Qingdao',           lon:120.361, lat:36.063, jp:false, labelOff:[ 8,  3] },
+  weihai:      { name:'Weihai',            lon:122.116, lat:37.506, jp:false, labelOff:[ 8,  3] },
+  busan:       { name:'Busan',             lon:129.032, lat:35.097, jp:false, labelOff:[ 8,  3] },
+  incheon:     { name:'Incheon',           lon:126.706, lat:37.455, jp:false, labelOff:[ 8,  3] },
+  donghae:     { name:'Donghae',           lon:129.114, lat:37.524, jp:false, labelOff:[ 8,  3] },
+  vladivostok: { name:'Vladivostok',       lon:131.882, lat:43.115, jp:false, labelOff:[ 8,  3] },
 };
 
-// ── Route data ─────────────────────────────────────────────────────────────
-// status: 'active' | 'suspended' | 'seasonal'
-const routes = [
-  // ── China ────────────────────────────────────────────────────────────────
-  {
-    id: 'sh-osaka',
-    from: 'shanghai', to: 'osaka',
-    operator: 'Shanghai Ferry Co. / Japan China International Ferry',
-    frequency: 'Weekly',
-    duration: '~48 hrs',
-    status: 'active',
-    color: COLORS.china,
-  },
-  {
-    id: 'sh-kobe',
-    from: 'shanghai', to: 'kobe',
-    operator: 'Orient Ferry (China)',
-    frequency: 'Weekly',
-    duration: '~46 hrs',
-    status: 'active',
-    color: COLORS.china,
-  },
-  {
-    id: 'tj-kobe',
-    from: 'tianjin', to: 'kobe',
-    operator: 'China-Japan International Ferry',
-    frequency: 'Weekly',
-    duration: '~45 hrs',
-    status: 'active',
-    color: COLORS.china,
-  },
-  {
-    id: 'dl-kobe',
-    from: 'dalian', to: 'kobe',
-    operator: 'China-Japan International Ferry',
-    frequency: 'Weekly',
-    duration: '~35 hrs',
-    status: 'active',
-    color: COLORS.china,
-  },
-  {
-    id: 'qd-shimonoseki',
-    from: 'qingdao', to: 'shimonoseki',
-    operator: 'Qingdao International Ferry',
-    frequency: 'Weekly',
-    duration: '~34 hrs',
-    status: 'active',
-    color: COLORS.china,
-  },
-  {
-    id: 'wh-osaka',
-    from: 'weihai', to: 'osaka',
-    operator: 'Xinjianzhen International Ferry',
-    frequency: 'Weekly',
-    duration: '~40 hrs',
-    status: 'active',
-    color: COLORS.china,
-  },
-  // ── South Korea ──────────────────────────────────────────────────────────
-  {
-    id: 'busan-shimonoseki',
-    from: 'busan', to: 'shimonoseki',
-    operator: 'Kampu Ferry (関釜フェリー)',
-    frequency: 'Daily',
-    duration: '~14 hrs',
-    status: 'active',
-    color: COLORS.korea,
-  },
-  {
-    id: 'busan-hakata',
-    from: 'busan', to: 'hakata',
-    operator: 'Camellia Line / Kyushu Yusen / JR Beetle (hydrofoil)',
-    frequency: 'Multiple daily',
-    duration: '3–6 hrs',
-    status: 'active',
-    color: COLORS.korea,
-  },
-  {
-    id: 'busan-osaka',
-    from: 'busan', to: 'osaka',
-    operator: 'Panstar Line (팬스타라인)',
-    frequency: 'Weekly',
-    duration: '~19 hrs',
-    status: 'active',
-    color: COLORS.korea,
-  },
-  {
-    id: 'busan-tsushima',
-    from: 'busan', to: 'izuhara',
-    operator: 'Mirajet / Tsushima Line',
-    frequency: 'Daily (seasonal)',
-    duration: '~1.5 hrs (hydrofoil)',
-    status: 'seasonal',
-    color: COLORS.korea,
-  },
-  {
-    id: 'incheon-osaka',
-    from: 'incheon', to: 'osaka',
-    operator: 'Panstar Line',
-    frequency: 'Weekly',
-    duration: '~42 hrs',
-    status: 'active',
-    color: COLORS.korea,
-  },
-  {
-    id: 'donghae-sakaiminato',
-    from: 'donghae', to: 'sakaiminato',
-    operator: 'DBS Cruise Ferry (DBS크루즈페리)',
-    frequency: 'Weekly',
-    duration: '~16 hrs',
-    status: 'active',
-    color: COLORS.korea,
-  },
-  // ── Russia ───────────────────────────────────────────────────────────────
-  {
-    id: 'vlad-sakaiminato',
-    from: 'vladivostok', to: 'sakaiminato',
-    operator: 'DBS Cruise Ferry (via Donghae)',
-    frequency: 'Weekly',
-    duration: '~42 hrs total',
-    status: 'suspended',
-    color: COLORS.russia,
-    note: 'Suspended since 2022 due to sanctions',
-  },
+// ── Routes ─────────────────────────────────────────────────────────────────
+const ROUTES = [
+  // China
+  { from:'shanghai',    to:'osaka',        cls:'route-china',  status:'active',
+    operator:'Shanghai Ferry / Japan China International Ferry', freq:'Weekly', dur:'~48 hrs' },
+  { from:'shanghai',    to:'kobe',         cls:'route-china',  status:'active',
+    operator:'Orient Ferry (China)', freq:'Weekly', dur:'~46 hrs' },
+  { from:'tianjin',     to:'kobe',         cls:'route-china',  status:'active',
+    operator:'China-Japan International Ferry', freq:'Weekly', dur:'~45 hrs' },
+  { from:'dalian',      to:'kobe',         cls:'route-china',  status:'active',
+    operator:'China-Japan International Ferry', freq:'Weekly', dur:'~35 hrs' },
+  { from:'qingdao',     to:'shimonoseki',  cls:'route-china',  status:'active',
+    operator:'Qingdao International Ferry', freq:'Weekly', dur:'~34 hrs' },
+  { from:'weihai',      to:'osaka',        cls:'route-china',  status:'active',
+    operator:'Xinjianzhen International Ferry', freq:'Weekly', dur:'~40 hrs' },
+  // Korea
+  { from:'busan',       to:'shimonoseki',  cls:'route-korea',  status:'active',
+    operator:'Kampu Ferry (関釜フェリー)', freq:'Daily', dur:'~14 hrs' },
+  { from:'busan',       to:'hakata',       cls:'route-korea',  status:'active',
+    operator:'Camellia Line / Kyushu Yusen / JR Beetle', freq:'Multiple daily', dur:'3–6 hrs' },
+  { from:'busan',       to:'osaka',        cls:'route-korea',  status:'active',
+    operator:'Panstar Line (팬스타라인)', freq:'Weekly', dur:'~19 hrs' },
+  { from:'busan',       to:'izuhara',      cls:'route-korea route-seasonal', status:'seasonal',
+    operator:'Mirajet / Tsushima Line', freq:'Daily (seasonal)', dur:'~1.5 hrs' },
+  { from:'incheon',     to:'osaka',        cls:'route-korea',  status:'active',
+    operator:'Panstar Line', freq:'Weekly', dur:'~42 hrs' },
+  { from:'donghae',     to:'sakaiminato',  cls:'route-korea',  status:'active',
+    operator:'DBS Cruise Ferry (DBS크루즈페리)', freq:'Weekly', dur:'~16 hrs' },
+  // Russia
+  { from:'vladivostok', to:'sakaiminato',  cls:'route-russia', status:'suspended',
+    operator:'DBS Cruise Ferry (via Donghae)',
+    freq:'Weekly (suspended)', dur:'~42 hrs',
+    note:'Suspended March 2022 following Russia sanctions' },
 ];
 
-// ── Marker styling ─────────────────────────────────────────────────────────
-function portMarker(port, isJapan) {
-  const color = isJapan ? '#f0c040' : '#adbac7';
-  return L.circleMarker(port.latlng, {
-    radius: isJapan ? 7 : 6,
-    fillColor: color,
-    color: '#0d1117',
-    weight: 2,
-    fillOpacity: 0.95,
-  });
+// ── SVG build ──────────────────────────────────────────────────────────────
+const svg = document.getElementById('map');
+
+function el(tag, attrs, parent) {
+  const e = document.createElementNS('http://www.w3.org/2000/svg', tag);
+  for (const [k, v] of Object.entries(attrs || {})) e.setAttribute(k, v);
+  (parent || svg).appendChild(e);
+  return e;
 }
 
-// Track which ports get drawn
-const drawnPorts = new Set();
+// Ocean background
+el('rect', { x:0, y:0, width:W, height:H, fill:'#1a2e45' });
 
-function addPort(key) {
-  if (drawnPorts.has(key)) return;
-  drawnPorts.add(key);
-  const port = ports[key];
-  const isJapan = port.country === 'Japan';
-  const marker = portMarker(port, isJapan);
-  marker.addTo(map);
-  marker.bindTooltip(port.name, { permanent: false, direction: 'top', offset: [0, -6] });
-  marker.bindPopup(`
-    <div class="popup-title">${port.name}</div>
-    <div class="popup-meta">Country: ${port.country}</div>
-  `);
+// Subtle ocean gradient
+const defs = el('defs');
+const grad = el('radialGradient', { id:'ocean-grad', cx:'70%', cy:'55%', r:'60%' }, defs);
+el('stop', { offset:'0%',   'stop-color':'#22405e', 'stop-opacity':'0.5' }, grad);
+el('stop', { offset:'100%', 'stop-color':'#0d1f30', 'stop-opacity':'0.5' }, grad);
+el('rect', { x:0, y:0, width:W, height:H, fill:'url(#ocean-grad)' });
+
+// Lat/lon grid
+for (let lat = 25; lat <= 45; lat += 5) {
+  const y = proj(0, lat).y;
+  el('line', { x1:0, y1:y, x2:W, y2:y, class:'gridline' });
+  el('text', { x:6, y:y-3, class:'gridlabel' }).textContent = `${lat}°N`;
+}
+for (let lon = 115; lon <= 145; lon += 5) {
+  const x = proj(lon, 0).x;
+  el('line', { x1:x, y1:0, x2:x, y2:H, class:'gridline' });
+  el('text', { x:x+3, y:H-6, class:'gridlabel' }).textContent = `${lon}°E`;
 }
 
-// ── Draw routes ────────────────────────────────────────────────────────────
-routes.forEach(route => {
-  const from = ports[route.from];
-  const to   = ports[route.to];
-  if (!from || !to) return;
+// Land
+el('path', { d: pathStr(LAND.continent), class:'land-mainland' });
+el('path', { d: pathStr(LAND.taiwan),    class:'land-mainland' });
+el('path', { d: pathStr(LAND.hokkaido),  class:'land-japan' });
+el('path', { d: pathStr(LAND.honshu),    class:'land-japan' });
+el('path', { d: pathStr(LAND.shikoku),   class:'land-japan' });
+el('path', { d: pathStr(LAND.kyushu),    class:'land-japan' });
+el('path', { d: pathStr(LAND.okinawa),   class:'land-japan' });
 
-  const dashArray = route.status === 'suspended' ? '6 6'
-                  : route.status === 'seasonal'  ? '10 4'
-                  : null;
+// ── Tooltip ────────────────────────────────────────────────────────────────
+const tooltip = document.getElementById('tooltip');
+let tooltipTarget = null;
 
-  const line = L.polyline([from.latlng, to.latlng], {
-    color: route.color,
-    weight: route.status === 'active' ? 2.5 : 1.8,
-    opacity: route.status === 'suspended' ? 0.4 : 0.85,
-    dashArray,
-    smoothFactor: 1,
-  }).addTo(map);
+function showTooltip(html, e) {
+  tooltip.innerHTML = html;
+  tooltip.style.display = 'block';
+  moveTooltip(e);
+}
+function moveTooltip(e) {
+  const wrap = document.getElementById('map-wrap');
+  const rect = wrap.getBoundingClientRect();
+  let tx = e.clientX - rect.left + 14;
+  let ty = e.clientY - rect.top  + 14;
+  if (tx + 275 > rect.width)  tx = e.clientX - rect.left - 275;
+  if (ty + 140 > rect.height) ty = e.clientY - rect.top  - 130;
+  tooltip.style.left = tx + 'px';
+  tooltip.style.top  = ty + 'px';
+}
+function hideTooltip() { tooltip.style.display = 'none'; }
 
-  const statusLabel = route.status === 'active'    ? '<span class="popup-badge badge-active">Active</span>'
-                    : route.status === 'suspended' ? '<span class="popup-badge badge-suspended">Suspended</span>'
-                    : '<span class="popup-badge badge-seasonal">Seasonal</span>';
-
-  line.bindPopup(`
-    <div class="popup-title">${from.name} → ${to.name}</div>
-    <div class="popup-meta">
-      Operator: ${route.operator}<br>
-      Frequency: ${route.frequency}<br>
-      Duration: ${route.duration}
-      ${route.note ? `<br><em>${route.note}</em>` : ''}
-    </div>
-    ${statusLabel}
-  `);
-
-  line.on('mouseover', function() { this.setStyle({ weight: this.options.weight + 2, opacity: 1 }); });
-  line.on('mouseout',  function() { this.setStyle({ weight: this.options.weight - 2, opacity: route.status === 'suspended' ? 0.4 : 0.85 }); });
-
-  addPort(route.from);
-  addPort(route.to);
+document.getElementById('map-wrap').addEventListener('mousemove', e => {
+  if (tooltip.style.display === 'block') moveTooltip(e);
 });
 
-// ── Legend ─────────────────────────────────────────────────────────────────
-const legend = L.control({ position: 'bottomleft' });
-legend.onAdd = () => {
-  const div = L.DomUtil.create('div', 'legend');
-  div.innerHTML = `
-    <h4>Origin</h4>
-    <div class="legend-item"><div class="legend-line" style="background:${COLORS.china}"></div> China</div>
-    <div class="legend-item"><div class="legend-line" style="background:${COLORS.korea}"></div> South Korea</div>
-    <div class="legend-item"><div class="legend-line" style="background:${COLORS.russia}"></div> Russia</div>
-    <br>
-    <h4>Status</h4>
-    <div class="legend-item"><div class="legend-line" style="background:#aaa"></div> Active (solid)</div>
-    <div class="legend-item"><div class="legend-line" style="background:#aaa;background:repeating-linear-gradient(90deg,#aaa 0,#aaa 6px,transparent 6px,transparent 10px);height:3px"></div> Seasonal (dashed)</div>
-    <div class="legend-item"><div class="legend-line" style="background:repeating-linear-gradient(90deg,#666 0,#666 6px,transparent 6px,transparent 12px);height:2px"></div> Suspended (dotted)</div>
-    <br>
-    <h4>Ports</h4>
-    <div class="legend-item"><div class="legend-dot" style="background:#f0c040;border-color:#0d1117"></div> Japan port</div>
-    <div class="legend-item"><div class="legend-dot" style="background:#adbac7;border-color:#0d1117"></div> Foreign port</div>
-  `;
-  return div;
-};
-legend.addTo(map);
+// ── Routes ─────────────────────────────────────────────────────────────────
+const routeLayer = el('g', { id:'routes' });
+ROUTES.forEach(r => {
+  const f = PORTS[r.from], t = PORTS[r.to];
+  const fp = proj(f.lon, f.lat), tp = proj(t.lon, t.lat);
+
+  // Slight midpoint offset for visual curvature
+  const mx = (fp.x + tp.x) / 2 + (tp.y - fp.y) * 0.08;
+  const my = (fp.y + tp.y) / 2 - (tp.x - fp.x) * 0.08;
+
+  const d = `M${fp.x.toFixed(1)},${fp.y.toFixed(1)} Q${mx.toFixed(1)},${my.toFixed(1)} ${tp.x.toFixed(1)},${tp.y.toFixed(1)}`;
+  const path = el('path', { d, class:`route ${r.cls}` }, routeLayer);
+
+  const badgeClass = r.status === 'active' ? 'badge-active' : r.status === 'suspended' ? 'badge-suspended' : 'badge-seasonal';
+  const statusLabel = r.status === 'active' ? 'Active' : r.status === 'suspended' ? 'Suspended' : 'Seasonal';
+
+  path.addEventListener('mouseenter', e => {
+    showTooltip(`
+      <div class="tt-title">${f.name} → ${t.name}</div>
+      <div class="tt-meta">
+        <b>Operator:</b> ${r.operator}<br>
+        <b>Frequency:</b> ${r.freq}<br>
+        <b>Duration:</b> ${r.dur}
+        ${r.note ? `<br><i style="color:#8b949e">${r.note}</i>` : ''}
+      </div>
+      <span class="tt-badge ${badgeClass}">${statusLabel}</span>
+    `, e);
+  });
+  path.addEventListener('mouseleave', hideTooltip);
+});
+
+// ── Ports ──────────────────────────────────────────────────────────────────
+const portLayer = el('g', { id:'ports' });
+Object.entries(PORTS).forEach(([key, p]) => {
+  const pt = proj(p.lon, p.lat);
+  const g = el('g', { class:`port ${p.jp ? 'port-japan' : 'port-foreign'}` }, portLayer);
+
+  el('circle', { class:'port-dot', cx:pt.x, cy:pt.y, r:6 }, g);
+
+  const lx = pt.x + p.labelOff[0];
+  const ly = pt.y + p.labelOff[1];
+  const lbl = el('text', { class:'port-label', x:lx, y:ly }, g);
+  lbl.textContent = p.name;
+
+  g.addEventListener('mouseenter', e => {
+    showTooltip(`<div class="tt-title">${p.name}</div><div class="tt-meta">Country: ${p.jp ? 'Japan' : 'International'}</div>`, e);
+  });
+  g.addEventListener('mouseleave', hideTooltip);
+});
+
+// ── Japan label ────────────────────────────────────────────────────────────
+const jl = el('text', { x:925, y:380, fill:'#4a6040', 'font-size':'11', 'font-weight':'600',
+  'letter-spacing':'3', opacity:'0.7', transform:'rotate(-25,925,380)' });
+jl.textContent = 'JAPAN';
+
+const cl = el('text', { x:120, y:480, fill:'#2a4028', 'font-size':'11', 'font-weight':'600',
+  'letter-spacing':'2', opacity:'0.7' });
+cl.textContent = 'CHINA';
+
+const kl = el('text', { x:490, y:390, fill:'#2a4028', 'font-size':'9', 'font-weight':'600',
+  'letter-spacing':'1', opacity:'0.7', transform:'rotate(-5,490,390)' });
+kl.textContent = 'KOREA';
+
+const rl = el('text', { x:650, y:90, fill:'#2a4028', 'font-size':'9', 'font-weight':'600',
+  opacity:'0.6' });
+rl.textContent = 'RUSSIA';
 </script>
 </body>
 </html>

--- a/ferry-lines-japan.html
+++ b/ferry-lines-japan.html
@@ -1,0 +1,345 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Ferry Lines to Japan</title>
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; background: #0d1117; color: #e6edf3; }
+
+    #header {
+      padding: 16px 24px;
+      background: #161b22;
+      border-bottom: 1px solid #30363d;
+      display: flex;
+      align-items: center;
+      gap: 12px;
+    }
+    #header h1 { font-size: 1.3rem; font-weight: 600; }
+    #header span { font-size: 0.85rem; color: #8b949e; }
+
+    #map { width: 100%; height: calc(100vh - 57px); }
+
+    /* Legend */
+    .legend {
+      background: rgba(22, 27, 34, 0.95);
+      border: 1px solid #30363d;
+      border-radius: 8px;
+      padding: 12px 16px;
+      min-width: 200px;
+      backdrop-filter: blur(4px);
+    }
+    .legend h4 { font-size: 0.78rem; text-transform: uppercase; letter-spacing: 0.08em; color: #8b949e; margin-bottom: 10px; }
+    .legend-item { display: flex; align-items: center; gap: 8px; margin-bottom: 7px; font-size: 0.83rem; }
+    .legend-line { width: 32px; height: 3px; border-radius: 2px; }
+    .legend-dot { width: 10px; height: 10px; border-radius: 50%; border: 2px solid #fff; }
+
+    /* Popup */
+    .leaflet-popup-content-wrapper {
+      background: #161b22;
+      border: 1px solid #30363d;
+      border-radius: 8px;
+      color: #e6edf3;
+      box-shadow: 0 8px 24px rgba(0,0,0,0.5);
+    }
+    .leaflet-popup-tip { background: #161b22; }
+    .leaflet-popup-content { margin: 12px 16px; min-width: 180px; }
+    .popup-title { font-weight: 600; font-size: 0.95rem; margin-bottom: 6px; }
+    .popup-meta { font-size: 0.8rem; color: #8b949e; line-height: 1.6; }
+    .popup-badge {
+      display: inline-block;
+      padding: 2px 8px;
+      border-radius: 12px;
+      font-size: 0.72rem;
+      font-weight: 600;
+      margin-top: 6px;
+    }
+    .badge-active { background: #1f6feb; color: #fff; }
+    .badge-suspended { background: #6e4040; color: #ffa0a0; }
+    .badge-seasonal { background: #3d4a1f; color: #b5e853; }
+
+    /* Tooltip */
+    .leaflet-tooltip {
+      background: #161b22;
+      border: 1px solid #30363d;
+      color: #e6edf3;
+      font-size: 0.78rem;
+      padding: 4px 8px;
+      border-radius: 4px;
+    }
+    .leaflet-tooltip-left::before, .leaflet-tooltip-right::before { border-right-color: #30363d; border-left-color: #30363d; }
+  </style>
+</head>
+<body>
+
+<div id="header">
+  <h1>Ferry Lines to Japan</h1>
+  <span>International ferry routes — hover routes &amp; ports for details</span>
+</div>
+<div id="map"></div>
+
+<script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+<script>
+// ── Map setup ──────────────────────────────────────────────────────────────
+const map = L.map('map', { center: [34, 128], zoom: 5, zoomControl: true });
+
+L.tileLayer('https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png', {
+  attribution: '© <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors © <a href="https://carto.com/">CARTO</a>',
+  subdomains: 'abcd', maxZoom: 19
+}).addTo(map);
+
+// ── Colours by country of origin ──────────────────────────────────────────
+const COLORS = {
+  china:  '#f78166',  // red-orange
+  korea:  '#58a6ff',  // blue
+  russia: '#bc8cff',  // purple
+  taiwan: '#ffa657',  // amber
+};
+
+// ── Port data ──────────────────────────────────────────────────────────────
+const ports = {
+  // Japanese ports
+  osaka:        { name: 'Osaka',          latlng: [34.646, 135.406], country: 'Japan' },
+  kobe:         { name: 'Kobe',           latlng: [34.682, 135.185], country: 'Japan' },
+  shimonoseki:  { name: 'Shimonoseki',    latlng: [33.954, 130.937], country: 'Japan' },
+  hakata:       { name: 'Hakata (Fukuoka)',latlng: [33.598, 130.399], country: 'Japan' },
+  sakaiminato:  { name: 'Sakaiminato',    latlng: [35.546, 133.228], country: 'Japan' },
+  naha:         { name: 'Naha (Okinawa)', latlng: [26.218, 127.665], country: 'Japan' },
+  izuhara:      { name: 'Izuhara (Tsushima)',latlng: [34.199, 129.290], country: 'Japan' },
+  hiroshima:    { name: 'Hiroshima',      latlng: [34.391, 132.455], country: 'Japan' },
+  // Chinese ports
+  shanghai:     { name: 'Shanghai',       latlng: [31.381, 121.618], country: 'China' },
+  tianjin:      { name: 'Tianjin (Xingang)', latlng: [38.993, 117.728], country: 'China' },
+  dalian:       { name: 'Dalian',         latlng: [38.929, 121.641], country: 'China' },
+  qingdao:      { name: 'Qingdao',        latlng: [36.063, 120.361], country: 'China' },
+  weihai:       { name: 'Weihai',         latlng: [37.506, 122.116], country: 'China' },
+  // Korean ports
+  busan:        { name: 'Busan',          latlng: [35.097, 129.032], country: 'South Korea' },
+  incheon:      { name: 'Incheon',        latlng: [37.455, 126.706], country: 'South Korea' },
+  donghae:      { name: 'Donghae',        latlng: [37.524, 129.114], country: 'South Korea' },
+  // Russian ports
+  vladivostok:  { name: 'Vladivostok',    latlng: [43.115, 131.882], country: 'Russia' },
+};
+
+// ── Route data ─────────────────────────────────────────────────────────────
+// status: 'active' | 'suspended' | 'seasonal'
+const routes = [
+  // ── China ────────────────────────────────────────────────────────────────
+  {
+    id: 'sh-osaka',
+    from: 'shanghai', to: 'osaka',
+    operator: 'Shanghai Ferry Co. / Japan China International Ferry',
+    frequency: 'Weekly',
+    duration: '~48 hrs',
+    status: 'active',
+    color: COLORS.china,
+  },
+  {
+    id: 'sh-kobe',
+    from: 'shanghai', to: 'kobe',
+    operator: 'Orient Ferry (China)',
+    frequency: 'Weekly',
+    duration: '~46 hrs',
+    status: 'active',
+    color: COLORS.china,
+  },
+  {
+    id: 'tj-kobe',
+    from: 'tianjin', to: 'kobe',
+    operator: 'China-Japan International Ferry',
+    frequency: 'Weekly',
+    duration: '~45 hrs',
+    status: 'active',
+    color: COLORS.china,
+  },
+  {
+    id: 'dl-kobe',
+    from: 'dalian', to: 'kobe',
+    operator: 'China-Japan International Ferry',
+    frequency: 'Weekly',
+    duration: '~35 hrs',
+    status: 'active',
+    color: COLORS.china,
+  },
+  {
+    id: 'qd-shimonoseki',
+    from: 'qingdao', to: 'shimonoseki',
+    operator: 'Qingdao International Ferry',
+    frequency: 'Weekly',
+    duration: '~34 hrs',
+    status: 'active',
+    color: COLORS.china,
+  },
+  {
+    id: 'wh-osaka',
+    from: 'weihai', to: 'osaka',
+    operator: 'Xinjianzhen International Ferry',
+    frequency: 'Weekly',
+    duration: '~40 hrs',
+    status: 'active',
+    color: COLORS.china,
+  },
+  // ── South Korea ──────────────────────────────────────────────────────────
+  {
+    id: 'busan-shimonoseki',
+    from: 'busan', to: 'shimonoseki',
+    operator: 'Kampu Ferry (関釜フェリー)',
+    frequency: 'Daily',
+    duration: '~14 hrs',
+    status: 'active',
+    color: COLORS.korea,
+  },
+  {
+    id: 'busan-hakata',
+    from: 'busan', to: 'hakata',
+    operator: 'Camellia Line / Kyushu Yusen / JR Beetle (hydrofoil)',
+    frequency: 'Multiple daily',
+    duration: '3–6 hrs',
+    status: 'active',
+    color: COLORS.korea,
+  },
+  {
+    id: 'busan-osaka',
+    from: 'busan', to: 'osaka',
+    operator: 'Panstar Line (팬스타라인)',
+    frequency: 'Weekly',
+    duration: '~19 hrs',
+    status: 'active',
+    color: COLORS.korea,
+  },
+  {
+    id: 'busan-tsushima',
+    from: 'busan', to: 'izuhara',
+    operator: 'Mirajet / Tsushima Line',
+    frequency: 'Daily (seasonal)',
+    duration: '~1.5 hrs (hydrofoil)',
+    status: 'seasonal',
+    color: COLORS.korea,
+  },
+  {
+    id: 'incheon-osaka',
+    from: 'incheon', to: 'osaka',
+    operator: 'Panstar Line',
+    frequency: 'Weekly',
+    duration: '~42 hrs',
+    status: 'active',
+    color: COLORS.korea,
+  },
+  {
+    id: 'donghae-sakaiminato',
+    from: 'donghae', to: 'sakaiminato',
+    operator: 'DBS Cruise Ferry (DBS크루즈페리)',
+    frequency: 'Weekly',
+    duration: '~16 hrs',
+    status: 'active',
+    color: COLORS.korea,
+  },
+  // ── Russia ───────────────────────────────────────────────────────────────
+  {
+    id: 'vlad-sakaiminato',
+    from: 'vladivostok', to: 'sakaiminato',
+    operator: 'DBS Cruise Ferry (via Donghae)',
+    frequency: 'Weekly',
+    duration: '~42 hrs total',
+    status: 'suspended',
+    color: COLORS.russia,
+    note: 'Suspended since 2022 due to sanctions',
+  },
+];
+
+// ── Marker styling ─────────────────────────────────────────────────────────
+function portMarker(port, isJapan) {
+  const color = isJapan ? '#f0c040' : '#adbac7';
+  return L.circleMarker(port.latlng, {
+    radius: isJapan ? 7 : 6,
+    fillColor: color,
+    color: '#0d1117',
+    weight: 2,
+    fillOpacity: 0.95,
+  });
+}
+
+// Track which ports get drawn
+const drawnPorts = new Set();
+
+function addPort(key) {
+  if (drawnPorts.has(key)) return;
+  drawnPorts.add(key);
+  const port = ports[key];
+  const isJapan = port.country === 'Japan';
+  const marker = portMarker(port, isJapan);
+  marker.addTo(map);
+  marker.bindTooltip(port.name, { permanent: false, direction: 'top', offset: [0, -6] });
+  marker.bindPopup(`
+    <div class="popup-title">${port.name}</div>
+    <div class="popup-meta">Country: ${port.country}</div>
+  `);
+}
+
+// ── Draw routes ────────────────────────────────────────────────────────────
+routes.forEach(route => {
+  const from = ports[route.from];
+  const to   = ports[route.to];
+  if (!from || !to) return;
+
+  const dashArray = route.status === 'suspended' ? '6 6'
+                  : route.status === 'seasonal'  ? '10 4'
+                  : null;
+
+  const line = L.polyline([from.latlng, to.latlng], {
+    color: route.color,
+    weight: route.status === 'active' ? 2.5 : 1.8,
+    opacity: route.status === 'suspended' ? 0.4 : 0.85,
+    dashArray,
+    smoothFactor: 1,
+  }).addTo(map);
+
+  const statusLabel = route.status === 'active'    ? '<span class="popup-badge badge-active">Active</span>'
+                    : route.status === 'suspended' ? '<span class="popup-badge badge-suspended">Suspended</span>'
+                    : '<span class="popup-badge badge-seasonal">Seasonal</span>';
+
+  line.bindPopup(`
+    <div class="popup-title">${from.name} → ${to.name}</div>
+    <div class="popup-meta">
+      Operator: ${route.operator}<br>
+      Frequency: ${route.frequency}<br>
+      Duration: ${route.duration}
+      ${route.note ? `<br><em>${route.note}</em>` : ''}
+    </div>
+    ${statusLabel}
+  `);
+
+  line.on('mouseover', function() { this.setStyle({ weight: this.options.weight + 2, opacity: 1 }); });
+  line.on('mouseout',  function() { this.setStyle({ weight: this.options.weight - 2, opacity: route.status === 'suspended' ? 0.4 : 0.85 }); });
+
+  addPort(route.from);
+  addPort(route.to);
+});
+
+// ── Legend ─────────────────────────────────────────────────────────────────
+const legend = L.control({ position: 'bottomleft' });
+legend.onAdd = () => {
+  const div = L.DomUtil.create('div', 'legend');
+  div.innerHTML = `
+    <h4>Origin</h4>
+    <div class="legend-item"><div class="legend-line" style="background:${COLORS.china}"></div> China</div>
+    <div class="legend-item"><div class="legend-line" style="background:${COLORS.korea}"></div> South Korea</div>
+    <div class="legend-item"><div class="legend-line" style="background:${COLORS.russia}"></div> Russia</div>
+    <br>
+    <h4>Status</h4>
+    <div class="legend-item"><div class="legend-line" style="background:#aaa"></div> Active (solid)</div>
+    <div class="legend-item"><div class="legend-line" style="background:#aaa;background:repeating-linear-gradient(90deg,#aaa 0,#aaa 6px,transparent 6px,transparent 10px);height:3px"></div> Seasonal (dashed)</div>
+    <div class="legend-item"><div class="legend-line" style="background:repeating-linear-gradient(90deg,#666 0,#666 6px,transparent 6px,transparent 12px);height:2px"></div> Suspended (dotted)</div>
+    <br>
+    <h4>Ports</h4>
+    <div class="legend-item"><div class="legend-dot" style="background:#f0c040;border-color:#0d1117"></div> Japan port</div>
+    <div class="legend-item"><div class="legend-dot" style="background:#adbac7;border-color:#0d1117"></div> Foreign port</div>
+  `;
+  return div;
+};
+legend.addTo(map);
+</script>
+</body>
+</html>


### PR DESCRIPTION
Interactive Leaflet.js map showing all major international ferry routes
to Japan from China, South Korea, and Russia, with operator details,
frequency, duration, and active/seasonal/suspended status.

https://claude.ai/code/session_01G7uaC9fqmkek4xuSLNzoX5